### PR TITLE
Обновление readconfig.inc.php в модуле MegaD

### DIFF
--- a/modules/megad/readconfig.inc.php
+++ b/modules/megad/readconfig.inc.php
@@ -29,7 +29,7 @@
 
     if (preg_match('/pty=(\d+)/', $line, $m2)) {
      $type=(int)$m2[1];
-    } elseif (preg_match('/ecmd=/', $line)) {
+    } /*elseif (preg_match('/ecmd=/', $line)) {
      $type=0;       
     } else {
      $type=1;       
@@ -41,7 +41,8 @@
     if ($i==16) {
      $port=16;
      $type=100;
-    }
+    }*/
+   
 
     if ($type!=='') {
      $prop=SQLSelectOne("SELECT * FROM megadproperties WHERE DEVICE_ID='".$record['ID']."' AND NUM='".$port."'");


### PR DESCRIPTION
В связи с выходом новой MegaD2561 к которой можно подключить два модуля расширения, порты в ней на вкладке "данные" определялись некорректно, это связано с портом 0 который почему-то всегда определялся как output (хотя в коде на первый взгляд все правильно) и портами 14,15,16 которые соответствуют входам/выходам подключенного модуля, а не внутреннему датчику температуры и ADC. С закомментированной частью кода все порты определяются корректно.